### PR TITLE
Use zero-latency jitter buffer

### DIFF
--- a/lib/membrane/live_compositor/live_compositor.ex
+++ b/lib/membrane/live_compositor/live_compositor.ex
@@ -1,21 +1,3 @@
-defmodule StreamFormatEraser do
-  use Membrane.Filter
-  def_input_pad :input, accepted_format: _any
-  def_output_pad :output, accepted_format: _any
-
-  @impl true
-  def handle_buffer(:input, buf, _ctx, state) do
-    {[buffer: {:output, buf}], state}
-  end
-
-
-  @impl true
-  def handle_stream_format(:input, _sf, _ctx, state) do
-    {[stream_format: {:output, %Membrane.RemoteStream{}}], state}
-  end
-
-end
-
 defmodule Membrane.LiveCompositor do
   @moduledoc """
   Membrane SDK for [LiveCompositor](https://github.com/membraneframework/live_compositor).
@@ -653,9 +635,8 @@ defmodule Membrane.LiveCompositor do
       |> via_out(Pad.ref(:output, ssrc),
         options: [depayloader: nil, clock_rate: 90_000]
       )
+      |> child(%Membrane.RTP.JitterBuffer{latency: 0, clock_rate: 90_000})
       |> child(RTP.H264.Depayloader)
-      |> child(StreamFormatEraser)
-      |> child(%Membrane.H264.Parser{generate_best_effort_timestamps: %{framerate: state.output_framerate}, output_alignment: :nalu})
       |> get_child({:output_processor, pad_id})
 
     actions = [spec: {links, group: output_group_id(pad_id)}]

--- a/lib/membrane/live_compositor/live_compositor.ex
+++ b/lib/membrane/live_compositor/live_compositor.ex
@@ -460,7 +460,7 @@ defmodule Membrane.LiveCompositor do
     links =
       bin_input(input_ref)
       |> via_in(Pad.ref(:input, ssrc),
-        options: [payloader: RTP.H264.Payloader]
+        options: [payloader: %RTP.H264.Payloader{mode: :single_nalu}]
       )
       |> child({:rtp_sender, pad_id}, RTP.SessionBin)
       |> via_out(Pad.ref(:rtp_output, ssrc), options: [payload_type: 96])

--- a/lib/membrane/live_compositor/live_compositor.ex
+++ b/lib/membrane/live_compositor/live_compositor.ex
@@ -654,8 +654,10 @@ defmodule Membrane.LiveCompositor do
     links =
       get_child({:rtp_receiver, ref})
       |> via_out(Pad.ref(:output, ssrc),
-        options: [depayloader: RTP.Opus.Depayloader, clock_rate: 48_000]
+        options: [depayloader: nil, clock_rate: 48_000]
       )
+      |> child(%Membrane.RTP.JitterBuffer{latency: 0, clock_rate: 48_000})
+      |> child(RTP.Opus.Depayloader)
       |> get_child({:output_processor, pad_id})
 
     {[spec: {links, group: output_group_id(pad_id)}], state}

--- a/mix.exs
+++ b/mix.exs
@@ -50,7 +50,6 @@ defmodule Membrane.LiveCompositor.Mixfile do
       {:membrane_tcp_plugin, "~> 0.5.0"},
       {:membrane_opus_plugin, "~> 0.20.1"},
       {:membrane_rtp_opus_plugin, "~> 0.9.0"},
-      {:membrane_h26x_plugin, "~> 0.10.0"},
       # VC server start
       {:muontrap, "~> 1.0"},
       # VC API

--- a/mix.exs
+++ b/mix.exs
@@ -50,6 +50,7 @@ defmodule Membrane.LiveCompositor.Mixfile do
       {:membrane_tcp_plugin, "~> 0.5.0"},
       {:membrane_opus_plugin, "~> 0.20.1"},
       {:membrane_rtp_opus_plugin, "~> 0.9.0"},
+      {:membrane_h26x_plugin, "~> 0.10.0"},
       # VC server start
       {:muontrap, "~> 1.0"},
       # VC API


### PR DESCRIPTION
This PR:
* uses jitter buffer that introduces no latency for H.264 stream in the compositor bin's output

Jitter buffer is not needed there, as we have a reliable TCP connection between the compositor server and the compositor bin's elements and that is why network packets aren't reordered. 