### PR TITLE
Don't setup a ResourceGuard when the LiveCompositor is already started

### DIFF
--- a/lib/membrane/live_compositor/live_compositor.ex
+++ b/lib/membrane/live_compositor/live_compositor.ex
@@ -420,11 +420,13 @@ defmodule Membrane.LiveCompositor do
     {:ok, lc_port, server_pid} =
       ServerRunner.ensure_server_started(opt)
 
-    Membrane.ResourceGuard.register(
-      ctx.resource_guard,
-      fn -> Process.exit(server_pid, :kill) end,
-      tag: :live_compositor_server
-    )
+    if opt.server_setup != :already_started do
+      Membrane.ResourceGuard.register(
+        ctx.resource_guard,
+        fn -> Process.exit(server_pid, :kill) end,
+        tag: :live_compositor_server
+      )
+    end
 
     opt.init_requests
     |> Enum.each(fn request ->


### PR DESCRIPTION
When `server_setup` is already started it implies the client has started the LiveCompositor outside of our control. In this case the `server_pid` is nil and creates an ArgumentError when we try to `Process.exit` 