### PR TITLE
Spawn live compositor servers underneath a DynamicSupervisor

### DIFF
--- a/lib/membrane/live_compositor/application.ex
+++ b/lib/membrane/live_compositor/application.ex
@@ -1,0 +1,15 @@
+defmodule Membrane.LiveCompositor.Application do
+  @moduledoc false
+  use Application
+
+  @impl Application
+  def start(_type, _args) do
+    Supervisor.start_link(
+      [
+        {DynamicSupervisor, name: Membrane.LiveCompositor.ServerSupervisor}
+      ],
+      strategy: :one_for_one,
+      name: __MODULE__
+    )
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -28,6 +28,7 @@ defmodule Membrane.LiveCompositor.Mixfile do
 
   def application do
     [
+      mod: {Membrane.LiveCompositor.Application, []},
       extra_applications: []
     ]
   end


### PR DESCRIPTION
We recently transitioned our app from using a global live compositor which we spawned in our supervision tree and used the `:already_started` mode back to relying on the plugin to start the compositor. However, my test logs were being spammed with output from how it was being spawned.

I changed this to rely on the MuonTrap.Daemon which can be spawned under a DynamicSupervisor. This allows the logs to be captured in the normal way and let any logger config work as expected.

There's definitely a problem with the fact that I'm using String.to_atom here. Let me know what you think, probably we just need to shove that responsibility to the caller. Also, I use :transient mode since I'm pretty sure the pipeline will die if the compositor crashes, but let me know if that isn't true.